### PR TITLE
Change to return `undefined` for invalid points, positions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 /**
- * @typedef {import('unist').Position} Position
+ * @typedef {import('unist').Position} UnistPosition
+ * @typedef {import('unist').Point} UnistPoint
  *
- * @typedef {[number, number]} RangeLike
+ * @typedef {[number | null | undefined, number | null | undefined]} RangeLike
  *
  * @typedef PointLike
  * @property {number | null | undefined} [line]
@@ -23,39 +24,49 @@
  *
  * @param {NodeLike | null | undefined} [node]
  *   estree node.
- * @returns {Position}
+ * @returns {UnistPosition | undefined}
  *   unist position.
  */
 export function positionFromEstree(node) {
   const nodeLike = node || {}
   const loc = nodeLike.loc || {}
-  const range = nodeLike.range || [0, 0]
-  const startColumn = loc.start
-    ? numberOrUndefined(loc.start.column)
-    : undefined
-  const endColumn = loc.end ? numberOrUndefined(loc.end.column) : undefined
+  const range = nodeLike.range || [undefined, undefined]
+  const start = pointOrUndefined(loc.start, range[0] || nodeLike.start)
+  const end = pointOrUndefined(loc.end, range[1] || nodeLike.end)
 
-  return {
-    start: {
-      // @ts-expect-error: return no point / no position next major.
-      line: loc.start ? numberOrUndefined(loc.start.line) : undefined,
-      // @ts-expect-error: return no point / no position next major.
-      column: startColumn === undefined ? undefined : startColumn + 1,
-      offset: numberOrUndefined(range[0] || nodeLike.start)
-    },
-    end: {
-      // @ts-expect-error: return no point / no position next major.
-      line: loc.end ? numberOrUndefined(loc.end.line) : undefined,
-      // @ts-expect-error: return no point / no position next major.
-      column: endColumn === undefined ? undefined : endColumn + 1,
-      offset: numberOrUndefined(range[1] || nodeLike.end)
+  if (start && end) {
+    return {start, end}
+  }
+}
+
+/**
+ *
+ * @param {unknown} estreePoint
+ * @param {unknown} estreeOffset
+ * @returns {UnistPoint | undefined}
+ */
+function pointOrUndefined(estreePoint, estreeOffset) {
+  if (estreePoint && typeof estreePoint === 'object') {
+    const line =
+      'line' in estreePoint ? numberOrUndefined(estreePoint.line) : undefined
+    const column =
+      'column' in estreePoint
+        ? numberOrUndefined(estreePoint.column)
+        : undefined
+
+    if (line && column !== undefined) {
+      return {
+        line,
+        column: column + 1,
+        offset: numberOrUndefined(estreeOffset)
+      }
     }
   }
 }
 
 /**
  *
- * @param {number | null | undefined} value
+ * @param {unknown} value
  * @returns {number | undefined}
  */
 function numberOrUndefined(value) {

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Turn an estree `node` into a unist `position`.
 
 ###### Returns
 
-unist position ([`Position`][position]).
+unist position, if valid ([`Position`][position] or `undefined`).
 
 ## Types
 

--- a/test.js
+++ b/test.js
@@ -13,19 +13,13 @@ test('positionFromEstree', () => {
 
   assert.deepEqual(
     positionFromEstree(),
-    {
-      start: {line: undefined, column: undefined, offset: undefined},
-      end: {line: undefined, column: undefined, offset: undefined}
-    },
+    undefined,
     'should support a missing node'
   )
 
   assert.deepEqual(
     positionFromEstree(parse('x', {ecmaVersion: 2020})),
-    {
-      start: {line: undefined, column: undefined, offset: 0},
-      end: {line: undefined, column: undefined, offset: 1}
-    },
+    undefined,
     'should support node w/o `loc`s'
   )
 
@@ -40,10 +34,21 @@ test('positionFromEstree', () => {
 
   assert.deepEqual(
     positionFromEstree(parse('x', {ecmaVersion: 2020, ranges: true})),
-    {
-      start: {line: undefined, column: undefined, offset: 0},
-      end: {line: undefined, column: undefined, offset: 1}
-    },
+    undefined,
     'should support node w/ `range`s'
+  )
+
+  assert.deepEqual(
+    positionFromEstree({loc: {start: {}, end: {}}}),
+    undefined,
+    'should handle points w/o line/column'
+  )
+
+  assert.deepEqual(
+    positionFromEstree({
+      loc: {start: {line: -1, column: -1}, end: {line: 1, column: 0}}
+    }),
+    undefined,
+    'should handle points w/ too low values'
   )
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Previously, position-like values were returned. Those values are not valid according to the types. JavaScript has improved a lot since this package was created. Optional chaining for example makes it easier to do without this.

Related-to: syntax-tree/unist-util-position#12.

<!--do not edit: pr-->
